### PR TITLE
Avoid HTTPS wrong domain warning from RSS feed

### DIFF
--- a/src/site/daily_rss.php
+++ b/src/site/daily_rss.php
@@ -22,7 +22,7 @@ echo "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>";
 
     <channel>
         <title>Gordianbla.de Daily Puzzle</title>
-        <link>https://www.gordianbla.de</link>
+        <link>https://gordianbla.de</link>
         <description>Daily Netrunner card puzzle</description>
         <language>en</language>
         <lastBuildDate><?php echo($today->format("r"));?></lastBuildDate>
@@ -32,7 +32,7 @@ echo "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>";
             for ($i=$days; $i>=$days-30; $i--) {
                 echo("<item>");
                 echo("<title>Daily Puzzle #".$i."</title>");
-                echo("<link>https://www.gordianbla.de</link>");
+                echo("<link>https://gordianbla.de</link>");
                 echo("<description>Today's daily puzzle. Give it a try over on https://gordianbla.de !</description>");
                 echo("<pubDate>".(clone $start)->modify("+".$i." day")->format("r")."</pubDate>");
 


### PR DESCRIPTION
The RSS feed returns https://www.gordianbla.de/ as a link which yields a browser warning

> does not trust this site because it uses a certificate that is not valid for www.gordianbla.de. The certificate is only valid for the following names: cloud.lostgeek.de, crow.lostgeek.de, dumpyard.lostgeek.de, lostgeek.de, phpmyadmin.lostgeek.de, wallabag.lostgeek.de

Removing the www. subdomain makes it work fine.